### PR TITLE
Fix detection of default docker machine in OSX

### DIFF
--- a/sphere-stack.sh
+++ b/sphere-stack.sh
@@ -26,7 +26,7 @@ domain() {
 
 machine() {
     if test -n "$DOCKER_HOST"; then
-		docker-machine ls | cut -c1-20 | grep "\*\$" | cut -f1 -d' '
+		docker-machine ls | cut -c1-20 | grep "\*" | cut -f1 -d' '
     else
 		echo ""
 		return 1


### PR DESCRIPTION
While running through he procedure, the script did not detect the default docker machine on my laptop (running OSX). Adapting the `grep` command fixed it for me.
